### PR TITLE
Detect Alan-files and color multi-line comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Alan for Vim
    ```
    set foldmethod=indent
    ```
-3. Open with `vim` the `alan`-file
+5. Open with `vim` the `alan`-file

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Alan for Vim
 ## Instructions
 1. Close all instances of `vim`.
 2. Put `sth.vim` in `~/.vim/syntax/sth.vim`
+3. Put `alan.vim` in `~/.vim/ftdetect/alan.vim`
 4. Add to `~/.vimrc`:
    ```
    set foldmethod=indent
-   setf sth
    ```
 3. Open with `vim` the `alan`-file

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Alan for Vim
 
 ## Instructions
 1. Close all instances of `vim`.
-2. Put `sth.vim` in in `~/.vim/syntax/sth.vim`
+2. Put `sth.vim` in `~/.vim/syntax/sth.vim`
 4. Add to `~/.vimrc`:
    ```
    set foldmethod=indent

--- a/alan.vim
+++ b/alan.vim
@@ -1,0 +1,1 @@
+au BufNewFile,BufRead *.alan setf sth

--- a/sth.vim
+++ b/sth.vim
@@ -2,6 +2,8 @@ syn region SpaceSingleQuoteString start=/\ '/ end=/'/
 syn region TABSingleQuoteString start=/\t'/ end=/'/
 syn region NLSingleQuoteString start=/^'/ end=/'/
 syn region DoubleQuoteString start=/"/ end=/"/
+syn region Comment start=/\/\*/ end=/\*\//
+syn region TODOComment start=/\/\*\ TODO/ end=/\*\//
 syn match Comment '\/\/.*$'
 syn keyword TypeKeyWord text number integer natural reference group component stategroup collection dictionary matrix densematrix sparsematrix
 syn match TODOComment '\/\/ TODO.*$'


### PR DESCRIPTION
I added support for multiline-comments and figured out how to detect Alan files based on the `.alan` file extension. I also fixed a few minor things in the README and removed the instruction in `.vimrc` telling Vim to recognise *all* otherwise unrecognised files as Alan files.